### PR TITLE
feature: add support for scrapping thermal subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ docker:
 This monitors the docker containers
 
 ```yaml
+thermal:
+  enabled: false
+```
+
+This allows you to monitor the temperature of the CPU
+
+```yaml
 smart_monitor:
   enabled: false
   timeout: 30s

--- a/telegraf/config.json
+++ b/telegraf/config.json
@@ -32,6 +32,9 @@
       "enabled" : false,
       "timeout" : "5s"
     },
+    "thermal" : {
+      "enabled" : false
+    },
     "smart_monitor" : {
       "enabled" : false,
       "timeout" : "30s"
@@ -72,6 +75,9 @@
     "docker" : {
       "enabled" : "bool",
       "timeout" : "str"
+    },
+    "thermal" : {
+      "enabled" : "bool"
     },
     "smart_monitor" : {
       "enabled" : "bool",

--- a/telegraf/run.sh
+++ b/telegraf/run.sh
@@ -143,6 +143,21 @@ if bashio::config.true 'ipmi_sensor.enabled'; then
   sed -i "s,TIMEOUT,${IPMI_TIMEOUT},g" $CONFIG
 fi
 
+if bashio::config.true 'thermal.enabled'; then
+  bashio::log.info "Updating config for thermal zone sensors"
+  for i in $(shopt -s nullglob; echo /sys/class/thermal/thermal_zone*); do
+    bashio::log.info "...$i"
+    name=$(basename "$i")
+    {
+      echo "[[inputs.file]]"
+      echo "  files = [\"$i/temp\"]"
+      echo "  name_override = \"$name\""
+      echo "  data_format = \"value\""
+      echo "  data_type = \"integer\""
+    } >> $CONFIG
+  done
+fi
+
 if bashio::config.true 'influxDBv2.enabled'; then
   bashio::log.info "Updating config for influxdbv2"
   {


### PR DESCRIPTION
Thanks for creating this addon, it's a nice and much lighter alternative to [hassio-addons/addon-glances](https://github.com/hassio-addons/addon-glances).
Please consider adding support for crapping of thermal Linux subsystem devices which on many platforms contains information about CPU temperature.