### PR TITLE
enhancement: install smartmontools from backports repository

### DIFF
--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -9,7 +9,7 @@ ARG TELEGRAF_VERSION
 
 RUN \
     apt-get update \
-    && apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools ipmitool \
+    && apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools/bionic-backports ipmitool \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then ARCH="armhf"; fi \


### PR DESCRIPTION
Install smartmontools from backports repository
    
Install newer version of smartmontools from bionic-backports repository to enable support for new USB SATA controllers.
    
Ubuntu Bionic main repository provides smartmontools version 6.5, while the backports repository provides version 7.0, which is newer by two years.