### PR TITLE
Update telegraf to 1.17.0

### DIFF
--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -9,19 +9,19 @@ ARG TELEGRAF_VERSION
 
 RUN \
     apt-get update \
-    && apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools/bionic-backports ipmitool \
+    && apt-get install -y --no-install-recommends iputils-ping snmp procps lm-sensors smartmontools ipmitool \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
     && if [ "${BUILD_ARCH}" = "armv7" ]; then ARCH="armhf"; fi \
     \
     && TELEGRAF="$TELEGRAF_VERSION" \
-    && curl -J -L -o /tmp/telegraf.deb \
+    && curl -qs -J -L -o /tmp/telegraf.deb \
         "https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF}-1_${ARCH}.deb"
 
-    RUN dpkg --install /tmp/telegraf.deb \
-    && rm -rf \
-        /tmp/* \
-        /var/lib/apt/lists/*
+RUN dpkg --install /tmp/telegraf.deb \
+&& rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/*
 
 EXPOSE 8092/udp 8094 8125/udp
 

--- a/telegraf/build.json
+++ b/telegraf/build.json
@@ -6,7 +6,7 @@
         "i386": "homeassistant/i386-base-debian:buster"
     },
     "args": {
-       "TELEGRAF_VERSION": "1.13.2"
+       "TELEGRAF_VERSION": "1.17.0"
    }
 }
 

--- a/telegraf/build.json
+++ b/telegraf/build.json
@@ -1,9 +1,9 @@
 {
     "build_from": {
-        "aarch64": "homeassistant/aarch64-base-ubuntu:latest",
-        "amd64": "homeassistant/amd64-base-ubuntu:latest",
-        "armv7": "homeassistant/armv7-base-ubuntu:latest",
-        "i386": "homeassistant/i386-base-ubuntu:latest"
+        "aarch64": "homeassistant/aarch64-base-debian:buster",
+        "amd64": "homeassistant/amd64-base-debian:buster",
+        "armv7": "homeassistant/armv7-base-debian:buster",
+        "i386": "homeassistant/i386-base-debian:buster"
     },
     "args": {
        "TELEGRAF_VERSION": "1.13.2"


### PR DESCRIPTION
# Fix or Feature Request?

This is a Fix :) 

The ubuntu latest is not playing nice with telegraf and it took me too long to find out why it wasn't working (Related to: https://github.com/home-assistant/docker-base/issues/70), so I took the liberty to migrate to debian buster and upgrade telegraf to version 1.17.0

# What does this solve
It allows a more recent version of telegraf and makes sure the build keeps working over time.