### PR TITLE
Enable prometheus exporter output for telegraf

### DIFF
--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -23,7 +23,7 @@ RUN \
         /tmp/* \
         /var/lib/apt/lists/*
 
-EXPOSE 8092/udp 8094 8125/udp
+EXPOSE 8092/udp 8094 8125/udp 9273/tcp
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/telegraf/config.json
+++ b/telegraf/config.json
@@ -59,6 +59,10 @@
       "organization": "",
       "token": "",
       "bucket": ""
+    },
+    "prometheus": {
+      "enabled": false,
+      "metrics_path": "/metrics"
     }
   },
   "schema": {
@@ -107,8 +111,14 @@
       "organization": "str",
       "token": "str",
       "bucket": "str"
+    },
+    "prometheus": {
+      "enabled": "bool",
+      "metrics_path": "str"
     }
   },
-  "ports" : {},
+  "ports" : {
+    "9273/tcp": 9273
+  },
   "image" : "sabuto/{arch}-hassio-telegraf"
 }

--- a/telegraf/run.sh
+++ b/telegraf/run.sh
@@ -192,7 +192,7 @@ else
     } >> $CONFIG
 
     PROM_METRICS_PATH="$( bashio::config 'prometheus.metrics_path' )"
-    sed -i "s,PROM_METRICS_PORT,${PROM_METRICS_PATH},g" $CONFIG
+    sed -i "s,PROM_METRICS_PATH,${PROM_METRICS_PATH},g" $CONFIG
   fi
 
 fi

--- a/telegraf/run.sh
+++ b/telegraf/run.sh
@@ -181,6 +181,20 @@ else
     sed -i "s,INFLUX_ORG,${INFLUXDBV2_ORG},g" $CONFIG
     sed -i "s,INFLUX_BUCKET,${INFLUXDBV2_BUCKET},g" $CONFIG
   fi
+
+  if bashio::config.true 'prometheus.enabled'; then
+    bashio::log.info "Updating config for prometheus client"
+    {
+      echo "[[outputs.prometheus_client]]"
+      echo "  listen = \":9273\""
+      echo "  path   = \"PROM_METRICS_PATH\""
+      echo "  metric_version = 2"
+    } >> $CONFIG
+
+    PROM_METRICS_PATH="$( bashio::config 'prometheus.metrics_path' )"
+    sed -i "s,PROM_METRICS_PORT,${PROM_METRICS_PATH},g" $CONFIG
+  fi
+
 fi
 
 bashio::log.info "Finished updating config, Starting Telegraf"


### PR DESCRIPTION
# Fix or Feature Request?
This is a feature request: Enable the prometheus exporter output for telegraf.

# What does this solve
It allows crawling telegraf with prometheus instead of influxdb.