### PR TITLE
Update run.sh

### DIFF
--- a/telegraf/run.sh
+++ b/telegraf/run.sh
@@ -119,6 +119,7 @@ else
       echo "[[inputs.docker]]"
       echo "  endpoint = 'unix:///var/run/docker.sock'"
       echo "  timeout = 'DOCKER_TIMEOUT'"
+      echo "  docker_label_include = ['engine_host','container_image','container_name','container_status','container_version']"
     } >> $CONFIG
 
     sed -i "s,DOCKER_TIMEOUT,${DOCKER_TIMEOUT},g" $CONFIG


### PR DESCRIPTION
The labels from Docker input should be limited, I believe these labels are sufficient, but if you prefer we can create a new option on add-on configuration, so the user can include or exclude labels to send to influx.

# Fix or Feature Request?
<!--- Is this pull request to fix something or is a feature request ---!>
<!--- If this is a fix has a issue been raised? (anything other than a typo) ---!>

# What does this solve
